### PR TITLE
fix import statements

### DIFF
--- a/dexter/README.md
+++ b/dexter/README.md
@@ -6,7 +6,7 @@ Dexter is a logging middleware inspired by [expressjs/morgan](https://github.com
 import { Drash } from "https://deno.land/x/drash@{version}/mod.ts";
 
 // Import the Dexter middleware function
-import { Dexter } from "https://deno.land/x/drash-middleware@{version}/dexter/mod.ts";
+import { Dexter } from "https://deno.land/x/drash_middleware@{version}/dexter/mod.ts";
 
 // Instantiate dexter
 const dexter = Dexter();
@@ -134,7 +134,7 @@ You can reuse Dexter in your codebase by accessing its `logger`. For example, if
     // File: app.ts
     import { Drash } from "https://deno.land/x/drash@{version}/mod.ts";
     import { HomeResource } from "./home_resource.ts";
-    import { Dexter } from "https://deno.land/x/drash-middleware@{version}/dexter.ts";
+    import { Dexter } from "https://deno.land/x/drash_middleware@{version}/dexter.ts";
 
     const dexter = Dexter({
       enabled: true,

--- a/paladin/README.md
+++ b/paladin/README.md
@@ -6,7 +6,7 @@ Paladin helps you secure your Drash applications by setting various HTTP headers
 import { Drash } from "https://deno.land/x/drash@{version}/mod.ts";
 
 // Import the Paladin middleware function
-import { Paladin } from "https://deno.land/x/drash-middleware@{version}/paladin/mod.ts";
+import { Paladin } from "https://deno.land/x/drash_middleware@{version}/paladin/mod.ts";
 
 // Instantiate paladin
 const paladin = Paladin();


### PR DESCRIPTION
**Description**

* Use `drash_middleware` and not `drash-middleware` in the import statements. I didn't know the module names were snake cased in deno's `database.json` file.