### PR TITLE
feat: upgrade drash to v1.2.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { Drash } from "https://deno.land/x/drash@v1.2.0/mod.ts";
+export { Drash } from "https://deno.land/x/drash@v1.2.1/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { Drash } from "https://deno.land/x/drash@v1.0.8/mod.ts";
+export { Drash } from "https://deno.land/x/drash@v1.2.0/mod.ts";


### PR DESCRIPTION
**Description**

*   Throws a error if you try to use the middleware on drash v1.2.0

**Other Notes**

*   N/A