### PR TITLE
Add console script to update dependency versions

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -7,7 +7,7 @@ jobs:
   update-dep:
     strategy:
       matrix:
-        deno: ["1.3.0"]
+        deno: ["1.3.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,8 +17,16 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
-      - name: Update Dependencies
+      - name: Update Main Dependencies
         run: deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm/mod.ts update
+
+      - name: Update CSRF Dependencies
+        run: |
+          cd csrf
+          deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm/mod.ts update
+
+      - name: Update Deno Version Occurances
+        run: deno run --allow-read --allow-net --allow-write console/update_dependency_version_strings.ts
 
       #- name: Update Test Dependencies
       #  run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        deno: ["1.3.0"]
+        deno: ["1.3.3"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -38,7 +38,7 @@ jobs:
   linter:
     strategy:
       matrix:
-        deno: ["1.3.0"]
+        deno: ["1.3.3"]
     # Only one OS is required since fmt is cross platform
     runs-on: ubuntu-latest
 

--- a/console/update_dependency_version_strings.ts
+++ b/console/update_dependency_version_strings.ts
@@ -1,0 +1,83 @@
+// Overview
+//
+// Updates deno version strings in files.
+// This scripts main purpose is to aid the `bumper`,
+// removing any extra manual work when we bump the deno version
+
+let fileContent = "";
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+let fetchRes = await fetch("https://cdn.deno.land/deno/meta/versions.json");
+let versions: {
+  latest: string;
+  versions: string[];
+} = await fetchRes.json(); // eg { latest: "v1.3.3", versions: ["v1.3.2", ...] }
+const latestDenoVersion = versions.latest.replace("v", "");
+fetchRes = await fetch("https://cdn.deno.land/drash/meta/versions.json");
+versions = await fetchRes.json()
+const latestDrashVersion = versions.latest
+
+// Master workflow
+fileContent = decoder.decode(
+  await Deno.readFile("./.github/workflows/master.yml"),
+);
+fileContent = fileContent.replace(
+  /deno: ["[0-9.]+[0-9.]+[0-9]"]/g,
+  `deno: ["${latestDenoVersion}"]`,
+);
+await Deno.writeFile(
+  "./.github/workflows/master.yml",
+  encoder.encode(fileContent),
+);
+
+// Bumper workflow
+fileContent = decoder.decode(
+  await Deno.readFile("./.github/workflows/bumper.yml"),
+);
+fileContent = fileContent.replace(
+  /deno: ["[0-9.]+[0-9.]+[0-9]"]/g,
+  `deno: ["${latestDenoVersion}"]`,
+);
+await Deno.writeFile(
+  "./.github/workflows/bumper.yml",
+  encoder.encode(fileContent),
+);
+
+// CSRF Readme, the drash version
+fileContent = decoder.decode(
+    await Deno.readFile("./csrf/README.md"),
+);
+fileContent = fileContent.replace(
+    /drash@[0-9.]+[0-9.]+[0-9]/g,
+    `drash@${latestDrashVersion}`,
+);
+await Deno.writeFile(
+    "./csrf/README.md",
+    encoder.encode(fileContent),
+);
+
+// Dexter Readme, the drash version
+fileContent = decoder.decode(
+    await Deno.readFile("./dexter/README.md"),
+);
+fileContent = fileContent.replace(
+    /drash@[0-9.]+[0-9.]+[0-9]/g,
+    `drash@${latestDrashVersion}`,
+);
+await Deno.writeFile(
+    "./dexter/README.md",
+    encoder.encode(fileContent),
+);
+
+// Paladin Readme, the drash version
+fileContent = decoder.decode(
+    await Deno.readFile("./paladin/README.md"),
+);
+fileContent = fileContent.replace(
+    /drash@[0-9.]+[0-9.]+[0-9]/g,
+    `drash@${latestDrashVersion}`,
+);
+await Deno.writeFile(
+    "./paladin/README.md",
+    encoder.encode(fileContent),
+);

--- a/console/update_dependency_version_strings.ts
+++ b/console/update_dependency_version_strings.ts
@@ -14,8 +14,8 @@ let versions: {
 } = await fetchRes.json(); // eg { latest: "v1.3.3", versions: ["v1.3.2", ...] }
 const latestDenoVersion = versions.latest.replace("v", "");
 fetchRes = await fetch("https://cdn.deno.land/drash/meta/versions.json");
-versions = await fetchRes.json()
-const latestDrashVersion = versions.latest
+versions = await fetchRes.json();
+const latestDrashVersion = versions.latest;
 
 // Master workflow
 fileContent = decoder.decode(
@@ -45,39 +45,39 @@ await Deno.writeFile(
 
 // CSRF Readme, the drash version
 fileContent = decoder.decode(
-    await Deno.readFile("./csrf/README.md"),
+  await Deno.readFile("./csrf/README.md"),
 );
 fileContent = fileContent.replace(
-    /drash@[0-9.]+[0-9.]+[0-9]/g,
-    `drash@${latestDrashVersion}`,
+  /drash@[0-9.]+[0-9.]+[0-9]/g,
+  `drash@${latestDrashVersion}`,
 );
 await Deno.writeFile(
-    "./csrf/README.md",
-    encoder.encode(fileContent),
+  "./csrf/README.md",
+  encoder.encode(fileContent),
 );
 
 // Dexter Readme, the drash version
 fileContent = decoder.decode(
-    await Deno.readFile("./dexter/README.md"),
+  await Deno.readFile("./dexter/README.md"),
 );
 fileContent = fileContent.replace(
-    /drash@[0-9.]+[0-9.]+[0-9]/g,
-    `drash@${latestDrashVersion}`,
+  /drash@[0-9.]+[0-9.]+[0-9]/g,
+  `drash@${latestDrashVersion}`,
 );
 await Deno.writeFile(
-    "./dexter/README.md",
-    encoder.encode(fileContent),
+  "./dexter/README.md",
+  encoder.encode(fileContent),
 );
 
 // Paladin Readme, the drash version
 fileContent = decoder.decode(
-    await Deno.readFile("./paladin/README.md"),
+  await Deno.readFile("./paladin/README.md"),
 );
 fileContent = fileContent.replace(
-    /drash@[0-9.]+[0-9.]+[0-9]/g,
-    `drash@${latestDrashVersion}`,
+  /drash@[0-9.]+[0-9.]+[0-9]/g,
+  `drash@${latestDrashVersion}`,
 );
 await Deno.writeFile(
-    "./paladin/README.md",
-    encoder.encode(fileContent),
+  "./paladin/README.md",
+  encoder.encode(fileContent),
 );

--- a/csrf/README.md
+++ b/csrf/README.md
@@ -3,7 +3,7 @@
 CSRF is a [CSRF])https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection middleware inspired by [expressjs/csurf](http://expressjs.com/en/resources/middleware/csurf.html). It can be simply placed as a middleware for your resources and you are all set!
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v{latest}/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
 
 // Import the Dexter middleware function
 import { CSRF } from "https://deno.land/x/drash_middleware@v0.5.0/csrf/mod.ts";

--- a/dexter/README.md
+++ b/dexter/README.md
@@ -3,7 +3,7 @@
 Dexter is a logging middleware inspired by [expressjs/morgan](https://github.com/expressjs/morgan). It is configurable and can be used throughout the request-resource-response lifecycle.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v{latest}/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
 
 // Import the Dexter middleware function
 import { Dexter } from "https://deno.land/x/drash_middleware@v0.5.0/dexter/mod.ts";

--- a/paladin/README.md
+++ b/paladin/README.md
@@ -3,7 +3,7 @@
 Paladin helps you secure your Drash applications by setting various HTTP headers. Inspired by [helmet](https://github.com/helmetjs/helmet). It is configurable and can be used throughout the request-resource-response lifecycle. This does not make your application bulletproof, but adds extra security layers.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v{latest}/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
 
 // Import the Paladin middleware function
 import { Paladin } from "https://deno.land/x/drash_middleware@v0.5.0/paladin/mod.ts";


### PR DESCRIPTION
**Description**

* Adds a script, similar to Rhum and Drash, to update the deno version in workflows, and drash versions in each middlewares readme, removing manual work from us for the bumper PR