### PR TITLE
chore: bump versions

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -7,7 +7,7 @@ jobs:
   update-dep:
     strategy:
       matrix:
-        deno: ["1.4.2"]
+        deno: ["1.4.5"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        deno: ["1.4.2"]
+        deno: ["1.4.5"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -38,7 +38,7 @@ jobs:
   linter:
     strategy:
       matrix:
-        deno: ["1.4.2"]
+        deno: ["1.4.5"]
     # Only one OS is required since fmt is cross platform
     runs-on: ubuntu-latest
 

--- a/csrf/README.md
+++ b/csrf/README.md
@@ -3,7 +3,7 @@
 CSRF is a [CSRF])https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection middleware inspired by [expressjs/csurf](http://expressjs.com/en/resources/middleware/csurf.html). It can be simply placed as a middleware for your resources and you are all set!
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
 
 // Import the Dexter middleware function
 import { CSRF } from "https://deno.land/x/drash_middleware@v0.5.1/csrf/mod.ts";

--- a/csrf/README.md
+++ b/csrf/README.md
@@ -3,10 +3,10 @@
 CSRF is a [CSRF])https://en.wikipedia.org/wiki/Cross-site_request_forgery) protection middleware inspired by [expressjs/csurf](http://expressjs.com/en/resources/middleware/csurf.html). It can be simply placed as a middleware for your resources and you are all set!
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
 
 // Import the Dexter middleware function
-import { CSRF } from "https://deno.land/x/drash_middleware@v0.5.0/csrf/mod.ts";
+import { CSRF } from "https://deno.land/x/drash_middleware@v0.5.1/csrf/mod.ts";
 
 // Instantiate csrf and generate the token
 const csrf = CSRF();

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
+export { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";

--- a/dexter/README.md
+++ b/dexter/README.md
@@ -3,10 +3,10 @@
 Dexter is a logging middleware inspired by [expressjs/morgan](https://github.com/expressjs/morgan). It is configurable and can be used throughout the request-resource-response lifecycle.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
 
 // Import the Dexter middleware function
-import { Dexter } from "https://deno.land/x/drash_middleware@v0.5.0/dexter/mod.ts";
+import { Dexter } from "https://deno.land/x/drash_middleware@v0.5.1/dexter/mod.ts";
 
 // Instantiate dexter
 const dexter = Dexter();

--- a/dexter/README.md
+++ b/dexter/README.md
@@ -3,7 +3,7 @@
 Dexter is a logging middleware inspired by [expressjs/morgan](https://github.com/expressjs/morgan). It is configurable and can be used throughout the request-resource-response lifecycle.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
 
 // Import the Dexter middleware function
 import { Dexter } from "https://deno.land/x/drash_middleware@v0.5.1/dexter/mod.ts";
@@ -132,7 +132,7 @@ You can reuse Dexter in your codebase by accessing its `logger`. For example, if
 
     ```typescript
     // File: app.ts
-    import { Drash } from "https://deno.land/x/drash@v{latest}/mod.ts";
+    import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
     import { HomeResource } from "./home_resource.ts";
     import { Dexter } from "https://deno.land/x/drash_middleware@v0.3.0/dexter.ts";
 
@@ -170,7 +170,7 @@ You can reuse Dexter in your codebase by accessing its `logger`. For example, if
 2. Create your `home_resource` file.
 
     ```typescript
-    import { Drash } from "https://deno.land/x/drash@v1.x/mod.ts";
+    import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
     import { dexter } from "./app.ts";
 
     export class HomeResource extends Drash.Http.Resource {

--- a/egg.json
+++ b/egg.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/drashland/deno-drash-middleware",
   "files": [
     "./**/*",
-    "./REAME.md",
+    "./README.md",
     "LICENSE",
     "./deps.ts",
     "./logo.svg"

--- a/egg.json
+++ b/egg.json
@@ -1,10 +1,15 @@
 {
   "name": "drash-middleware",
   "description": "A middleware library for Drash.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "stable": true,
   "repository": "https://github.com/drashland/deno-drash-middleware",
   "files": [
-    "./**/*"
-  ]
+    "./**/*",
+    "./REAME.md",
+    "LICENSE",
+    "./deps.ts",
+    "./logo.svg"
+  ],
+  "checkAll": false
 }

--- a/paladin/README.md
+++ b/paladin/README.md
@@ -3,10 +3,10 @@
 Paladin helps you secure your Drash applications by setting various HTTP headers. Inspired by [helmet](https://github.com/helmetjs/helmet). It is configurable and can be used throughout the request-resource-response lifecycle. This does not make your application bulletproof, but adds extra security layers.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.3/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
 
 // Import the Paladin middleware function
-import { Paladin } from "https://deno.land/x/drash_middleware@v0.5.0/paladin/mod.ts";
+import { Paladin } from "https://deno.land/x/drash_middleware@v0.5.1/paladin/mod.ts";
 
 // Instantiate paladin
 const paladin = Paladin();

--- a/paladin/README.md
+++ b/paladin/README.md
@@ -3,7 +3,7 @@
 Paladin helps you secure your Drash applications by setting various HTTP headers. Inspired by [helmet](https://github.com/helmetjs/helmet). It is configurable and can be used throughout the request-resource-response lifecycle. This does not make your application bulletproof, but adds extra security layers.
 
 ```typescript
-import { Drash } from "https://deno.land/x/drash@v1.2.4/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
 
 // Import the Paladin middleware function
 import { Paladin } from "https://deno.land/x/drash_middleware@v0.5.1/paladin/mod.ts";


### PR DESCRIPTION
**Description**

* this repo is incompatible when putting a middleware into a drash v1.2.4 server, which is the reason for this release