### PR TITLE
feat: Add cookie support for CSRF

### DIFF
--- a/csrf/README.md
+++ b/csrf/README.md
@@ -8,15 +8,23 @@ import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts";
 // Import the Dexter middleware function
 import { CSRF } from "https://deno.land/x/drash_middleware@v0.5.1/csrf/mod.ts";
 
-// Instantiate csrf and generate the token
+// Instantiate csrf and generate the token.
 const csrf = CSRF();
 // Alongside `csrf` being a middleware, you can access the token:
 //     `console.log(csrf.token)`
+// This means you can pass it down to your view, or set as a cookie
 
 // Create your server and resource, and plug in csrf to the middleware config
 class Resource extends Drash.Http.Resource {
   public GET () {
-  
+    this.response.headers.set("X-CSRF-TOKEN", csrf.token)
+    // or
+    this.response.render("/index.html", { csrf: csrf.token })
+    // or (only when `cookie` is set)
+    this.response.setCookie({
+      name: "X-CSRF-TOKEN",
+      value: csrf.token
+    })
   }
   
   @Drash.Http.Middleware({

--- a/csrf/mod.ts
+++ b/csrf/mod.ts
@@ -17,14 +17,11 @@ type Options = {
   cookie?: boolean;
 };
 
-const defaultOptions = {
+const defaultOptions: Options = {
   cookie: false,
 };
 
-export function CSRF(options?: Options) {
-  if (!options) {
-    options = defaultOptions;
-  }
+export function CSRF(options: Options = defaultOptions) {
   const csrf = <F> function csrf(
     request: Drash.Http.Request,
     response?: Drash.Http.Response,
@@ -32,7 +29,7 @@ export function CSRF(options?: Options) {
     if (response) {
       let requestToken: string | null = "";
 
-      if (options!.cookie === true) {
+      if (options.cookie === true) {
         requestToken = request.getCookie("X-CSRF-TOKEN");
       } else {
         requestToken = request.headers.get("X-CSRF-TOKEN");

--- a/csrf/mod.ts
+++ b/csrf/mod.ts
@@ -13,13 +13,31 @@ const primaryToken = createHash("sha512");
 primaryToken.update(v4.generate());
 const primaryTokenString = primaryToken.toString();
 
-export function CSRF() {
+type Options = {
+  cookie?: boolean
+}
+
+const defaultOptions = {
+  cookie: false
+}
+
+export function CSRF(options?: Options) {
+  if (!options) {
+    options = defaultOptions
+  }
   const csrf = <F> function csrf(
     request: Drash.Http.Request,
     response?: Drash.Http.Response,
   ): void {
     if (response) {
-      const requestToken = request.headers.get("X-CSRF-TOKEN");
+
+      let requestToken: string|null = "";
+
+      if (options!.cookie === true) {
+        requestToken = request.getCookie("X-CSRF-TOKEN")
+      } else {
+        requestToken = request.headers.get("X-CSRF-TOKEN");
+      }
 
       if (!requestToken) {
         throw new Drash.Exceptions.HttpMiddlewareException(

--- a/csrf/mod.ts
+++ b/csrf/mod.ts
@@ -14,27 +14,26 @@ primaryToken.update(v4.generate());
 const primaryTokenString = primaryToken.toString();
 
 type Options = {
-  cookie?: boolean
-}
+  cookie?: boolean;
+};
 
 const defaultOptions = {
-  cookie: false
-}
+  cookie: false,
+};
 
 export function CSRF(options?: Options) {
   if (!options) {
-    options = defaultOptions
+    options = defaultOptions;
   }
   const csrf = <F> function csrf(
     request: Drash.Http.Request,
     response?: Drash.Http.Response,
   ): void {
     if (response) {
-
-      let requestToken: string|null = "";
+      let requestToken: string | null = "";
 
       if (options!.cookie === true) {
-        requestToken = request.getCookie("X-CSRF-TOKEN")
+        requestToken = request.getCookie("X-CSRF-TOKEN");
       } else {
         requestToken = request.headers.get("X-CSRF-TOKEN");
       }

--- a/csrf/tests/mod_test.ts
+++ b/csrf/tests/mod_test.ts
@@ -2,36 +2,61 @@ import { CSRF } from "../mod.ts";
 import { Drash } from "../../deps.ts";
 import { Rhum } from "../../test_deps.ts";
 
-const csrf = CSRF();
+const csrfWithoutCookie = CSRF();
+const csrfWithCookie = CSRF({ cookie: true })
 
 /**
  * This resource resembles the following:
  *     1. On any route other than login/register/etc, supply the csrf token on GET requests
  *     2. On requests MADE to the server,  check the token was passed in
  */
-class Resource extends Drash.Http.Resource {
+class ResourceNoCookie extends Drash.Http.Resource {
   static paths = ["/"];
 
   public GET() {
     // Give token to the 'view'
-    this.response.headers.set("X-CSRF-TOKEN", csrf.token);
-    this.response.body = csrf.token;
+    this.response.headers.set("X-CSRF-TOKEN", csrfWithoutCookie.token);
+    this.response.body = csrfWithoutCookie.token;
     return this.response;
   }
 
   @Drash.Http.Middleware({
-    before_request: [csrf],
+    before_request: [csrfWithoutCookie],
     after_request: [],
   })
   public POST() {
     // request should have token
-    this.response.body = "Success; " + csrf.token;
+    this.response.body = "Success; " + csrfWithoutCookie.token;
+    return this.response;
+  }
+}
+
+class ResourceWithCookie extends Drash.Http.Resource {
+  static paths = ["/cookie"];
+
+  public GET() {
+    // Give token to the 'view'
+    this.response.setCookie({
+      name: "X-CSRF-TOKEN",
+      value: csrfWithCookie.token
+    });
+    this.response.body = csrfWithCookie.token;
+    return this.response;
+  }
+
+  @Drash.Http.Middleware({
+    before_request: [csrfWithCookie],
+    after_request: [],
+  })
+  public POST() {
+    // request should have token
+    this.response.body = "Success; " + csrfWithCookie.token;
     return this.response;
   }
 }
 
 const server = new Drash.Http.Server({
-  resources: [Resource],
+  resources: [ResourceNoCookie, ResourceWithCookie],
 });
 
 async function runServer() {
@@ -47,7 +72,7 @@ Rhum.testPlan("CSRF - mod_test.ts", () => {
   Rhum.testSuite("csrf", () => {
     Rhum.testCase("`csrf.token` Should return a valid token", () => {
       Rhum.asserts.assertEquals(
-        csrf.token.match("[a-zA-Z0-9]{43}") !== null,
+          csrfWithoutCookie.token.match("[a-zA-Z0-9]{43}") !== null,
         true,
       );
     });
@@ -58,13 +83,13 @@ Rhum.testPlan("CSRF - mod_test.ts", () => {
         const firstRes = await fetch("http://localhost:1337");
         await firstRes.arrayBuffer();
         Rhum.asserts.assertEquals(
-          firstRes.headers.get("X-CSRF-TOKEN") === csrf.token,
+          firstRes.headers.get("X-CSRF-TOKEN") === csrfWithoutCookie.token,
           true,
         );
         const secondRes = await fetch("http://localhost:1337");
         await secondRes.arrayBuffer();
         Rhum.asserts.assertEquals(
-          secondRes.headers.get("X-CSRF-TOKEN") === csrf.token,
+          secondRes.headers.get("X-CSRF-TOKEN") === csrfWithoutCookie.token,
           true,
         );
         server.close();
@@ -111,17 +136,26 @@ Rhum.testPlan("CSRF - mod_test.ts", () => {
         const res = await fetch("http://localhost:1337", {
           method: "POST",
           headers: {
-            "X-CSRF-TOKEN": csrf.token,
+            "X-CSRF-TOKEN": csrfWithoutCookie.token,
           },
         });
         Rhum.asserts.assertEquals(res.status, 200);
         Rhum.asserts.assertEquals(
           await res.text(),
-          '"Success; ' + csrf.token + '"',
+          '"Success; ' + csrfWithoutCookie.token + '"',
         );
         server.close();
       },
     );
+    Rhum.testCase("Should allow to set the token as a cookie", async () => {
+      await runServer()
+      const res = await fetch("http://localhost:1337/cookie")
+      await res.json()
+      const headers = res.headers
+      const token = headers.get("set-cookie")!.split("=")[1]
+      Rhum.asserts.assertEquals(token, csrfWithCookie.token)
+      server.close()
+    })
   });
 });
 

--- a/csrf/tests/mod_test.ts
+++ b/csrf/tests/mod_test.ts
@@ -3,7 +3,7 @@ import { Drash } from "../../deps.ts";
 import { Rhum } from "../../test_deps.ts";
 
 const csrfWithoutCookie = CSRF();
-const csrfWithCookie = CSRF({ cookie: true })
+const csrfWithCookie = CSRF({ cookie: true });
 
 /**
  * This resource resembles the following:
@@ -38,7 +38,7 @@ class ResourceWithCookie extends Drash.Http.Resource {
     // Give token to the 'view'
     this.response.setCookie({
       name: "X-CSRF-TOKEN",
-      value: csrfWithCookie.token
+      value: csrfWithCookie.token,
     });
     this.response.body = csrfWithCookie.token;
     return this.response;
@@ -72,7 +72,7 @@ Rhum.testPlan("CSRF - mod_test.ts", () => {
   Rhum.testSuite("csrf", () => {
     Rhum.testCase("`csrf.token` Should return a valid token", () => {
       Rhum.asserts.assertEquals(
-          csrfWithoutCookie.token.match("[a-zA-Z0-9]{43}") !== null,
+        csrfWithoutCookie.token.match("[a-zA-Z0-9]{43}") !== null,
         true,
       );
     });
@@ -148,14 +148,14 @@ Rhum.testPlan("CSRF - mod_test.ts", () => {
       },
     );
     Rhum.testCase("Should allow to set the token as a cookie", async () => {
-      await runServer()
-      const res = await fetch("http://localhost:1337/cookie")
-      await res.json()
-      const headers = res.headers
-      const token = headers.get("set-cookie")!.split("=")[1]
-      Rhum.asserts.assertEquals(token, csrfWithCookie.token)
-      server.close()
-    })
+      await runServer();
+      const res = await fetch("http://localhost:1337/cookie");
+      await res.json();
+      const headers = res.headers;
+      const token = headers.get("set-cookie")!.split("=")[1];
+      Rhum.asserts.assertEquals(token, csrfWithCookie.token);
+      server.close();
+    });
   });
 });
 


### PR DESCRIPTION
Addresses #56 

**Description**

* Update docs
* Add ability to specify cookie, so the token is grabbed from the cookies and not a header