### PR TITLE
fix(serve_typescript): Support compiler options

### DIFF
--- a/serve_typescript/mod.ts
+++ b/serve_typescript/mod.ts
@@ -7,7 +7,7 @@ interface IFile {
 
 interface IOptions {
   files: IFile[];
-  compilerOptions?: Deno.compilerOptions
+  compilerOptions?: Deno.compilerOptions;
 }
 
 export function ServeTypeScript(options: IOptions) {
@@ -33,20 +33,23 @@ export function ServeTypeScript(options: IOptions) {
       const file = options.files[index];
 
       try {
-        const { diagnostics, files } = options.compilerOptions ? await Deno.emit(
-          file.source, {
-            compilerOptions: options.compilerOptions
-          }
-        ) : await Deno.emit(file.source);
+        const { diagnostics, files } = options.compilerOptions
+          ? await Deno.emit(
+            file.source,
+            {
+              compilerOptions: options.compilerOptions,
+            },
+          )
+          : await Deno.emit(file.source);
         const fileKey = Object.keys(files).find((filename) => {
           return filename.includes(".ts.js.map") === false;
         }) as string;
         const outputString = files[fileKey];
 
-        const formattedDiagnostics = Deno.formatDiagnostics(diagnostics)
+        const formattedDiagnostics = Deno.formatDiagnostics(diagnostics);
         if (formattedDiagnostics !== "") {
-          console.error(formattedDiagnostics)
-          Deno.exit(1)
+          console.error(formattedDiagnostics);
+          Deno.exit(1);
         }
 
         // Store the compiled out in the

--- a/serve_typescript/mod.ts
+++ b/serve_typescript/mod.ts
@@ -33,14 +33,12 @@ export function ServeTypeScript(options: IOptions) {
       const file = options.files[index];
 
       try {
-        const { diagnostics, files } = options.compilerOptions
-          ? await Deno.emit(
-            file.source,
-            {
-              compilerOptions: options.compilerOptions,
-            },
-          )
-          : await Deno.emit(file.source);
+        const { diagnostics, files } = await Deno.emit(
+          file.source,
+          {
+            compilerOptions: options.compilerOptions ?? {},
+          },
+        );
         const fileKey = Object.keys(files).find((filename) => {
           return filename.includes(".ts.js.map") === false;
         }) as string;

--- a/serve_typescript/mod.ts
+++ b/serve_typescript/mod.ts
@@ -7,7 +7,7 @@ interface IFile {
 
 interface IOptions {
   files: IFile[];
-  compilerOptions?: Deno.compilerOptions;
+  compilerOptions?: Deno.CompilerOptions;
 }
 
 export function ServeTypeScript(options: IOptions) {
@@ -48,8 +48,7 @@ export function ServeTypeScript(options: IOptions) {
 
         const formattedDiagnostics = Deno.formatDiagnostics(diagnostics);
         if (formattedDiagnostics !== "") {
-          console.error(formattedDiagnostics);
-          Deno.exit(1);
+          throw new Error(formattedDiagnostics);
         }
 
         // Store the compiled out in the

--- a/serve_typescript/tests/data/my_ts.ts
+++ b/serve_typescript/tests/data/my_ts.ts
@@ -22,3 +22,5 @@ export class User extends Employee {
     super(details);
   }
 }
+
+const something = document.body

--- a/serve_typescript/tests/data/my_ts.ts
+++ b/serve_typescript/tests/data/my_ts.ts
@@ -23,4 +23,4 @@ export class User extends Employee {
   }
 }
 
-const something = document.body
+const something = document.body;

--- a/serve_typescript/tests/mod_test.ts
+++ b/serve_typescript/tests/mod_test.ts
@@ -51,8 +51,8 @@ Rhum.testPlan("ServeTypeScript - mod_test.ts", () => {
           },
         ],
         compilerOptions: {
-          lib: ["dom"]
-        }
+          lib: ["dom"],
+        },
       });
       await serveTs.compile();
       await serveTs.run(

--- a/serve_typescript/tests/mod_test.ts
+++ b/serve_typescript/tests/mod_test.ts
@@ -33,8 +33,8 @@ Rhum.testPlan("ServeTypeScript - mod_test.ts", () => {
           errMsg = err.message;
         }
         Rhum.asserts.assertEquals(
-          errMsg,
-          "User error. ./serve_typescript/tests/data/invalid_ts.ts:0:27 - Cannot find name 's'.",
+          errMsg.indexOf("Cannot find name 's'.") !== -1,
+          true,
         );
       },
     );
@@ -51,7 +51,7 @@ Rhum.testPlan("ServeTypeScript - mod_test.ts", () => {
           },
         ],
         compilerOptions: {
-          lib: ["dom"],
+          lib: ["dom", "DOM.Iterable", "esnext"],
         },
       });
       await serveTs.compile();
@@ -76,7 +76,8 @@ Rhum.testPlan("ServeTypeScript - mod_test.ts", () => {
           "    constructor(details) {\n" +
           "        super(details);\n" +
           "    }\n" +
-          "}\n",
+          "}\n" +
+          "const something = document.body;\n",
       );
     });
   });

--- a/serve_typescript/tests/mod_test.ts
+++ b/serve_typescript/tests/mod_test.ts
@@ -50,6 +50,9 @@ Rhum.testPlan("ServeTypeScript - mod_test.ts", () => {
             target: "/assets/compiled.ts",
           },
         ],
+        compilerOptions: {
+          lib: ["dom"]
+        }
       });
       await serveTs.compile();
       await serveTs.run(


### PR DESCRIPTION
Serve TS doesn't support compiler options, so that means if any client side code uses the DOM methods, it errors and won't work.

For example, @closet6's problem they had on the discord:

![image](https://user-images.githubusercontent.com/47337480/121582546-09b00d00-ca27-11eb-9cde-ec5a303bd2c9.png)

