### PR TITLE
docs(serve_typescript): Add documentation on compilerOptions

### DIFF
--- a/serve_typescript/README.md
+++ b/serve_typescript/README.md
@@ -32,12 +32,17 @@ const serveTs = ServeTypeScript({
       target: "/ts/my_ts.ts", // the URI this file is accessible at (e.g., localhost:1447/ts/my_ts.ts)
     },
   ],
+  // compilerOptions: {
+  //   lib: ["dom", "DOM.Iterable", "esnext"]
+  // }
 });
 ```
 
 ## Configuration
 
 ### `files`
+
+
 
 This config is required. ServeTypeScript cannot run unless it is given files to
 compile during compile time. Compile time is when the Drash server is being
@@ -59,6 +64,24 @@ URI that the file is accessible at. For example, if you want to serve your
 TypeScript file at the `/ts/my_ts.ts` URI, then define `target` as
 `/ts/my_ts.ts`. When a request is made to `http://yourserver.com/ts/my_ts.ts`,
 your compiled TypeScript will be returned as the response.
+
+
+
+
+### `compilerOptions`
+
+This property is optional, and is used when the middleware is emitting the source file. It is of type `Deno.compilerOptions`, and you can find more information in [Deno's Documentation](https://doc.deno.land/builtin/unstable#Deno.CompilerOptions).
+
+```ts
+const serverTs = ServerTypeScript({
+  files: [...],
+  compilerOptions: {
+    lib: ["dom", "DOM.Iterable", "esnext"] // most common libs to use when targetting the DOM
+  }
+});
+```
+
+That is just one of the many properties you can specify inside `compilerOptions`.
 
 ## Tutorial: Writing Front-end TypeScript
 

--- a/serve_typescript/README.md
+++ b/serve_typescript/README.md
@@ -42,8 +42,6 @@ const serveTs = ServeTypeScript({
 
 ### `files`
 
-
-
 This config is required. ServeTypeScript cannot run unless it is given files to
 compile during compile time. Compile time is when the Drash server is being
 created.
@@ -65,12 +63,12 @@ TypeScript file at the `/ts/my_ts.ts` URI, then define `target` as
 `/ts/my_ts.ts`. When a request is made to `http://yourserver.com/ts/my_ts.ts`,
 your compiled TypeScript will be returned as the response.
 
-
-
-
 ### `compilerOptions`
 
-This property is optional, and is used when the middleware is emitting the source file. It is of type `Deno.compilerOptions`, and you can find more information in [Deno's Documentation](https://doc.deno.land/builtin/unstable#Deno.CompilerOptions).
+This property is optional, and is used when the middleware is emitting the
+source file. It is of type `Deno.compilerOptions`, and you can find more
+information in
+[Deno's Documentation](https://doc.deno.land/builtin/unstable#Deno.CompilerOptions).
 
 ```ts
 const serverTs = ServerTypeScript({
@@ -81,7 +79,8 @@ const serverTs = ServerTypeScript({
 });
 ```
 
-That is just one of the many properties you can specify inside `compilerOptions`.
+That is just one of the many properties you can specify inside
+`compilerOptions`.
 
 ## Tutorial: Writing Front-end TypeScript
 


### PR DESCRIPTION
I missed adding this when I added this feature
