### PR TITLE
[WIP] feat: Add rate limiter middleware

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           deno test -A --unstable serve_typescript/tests/mod_test.ts
 
+      - name: Rate Limiter
+        run: |
+          deno test -A rate_limiter
+
   linter:
     # Only one OS is required since fmt is cross platform
     runs-on: ubuntu-latest

--- a/console/bumper_ci_service_files.ts
+++ b/console/bumper_ci_service_files.ts
@@ -38,6 +38,11 @@ export const bumpVersionFiles = [
     replaceWith: `drash_middleware@v{{ thisModulesLatestVersion }}`,
   },
   {
+    filename: "./rate_limiter/README.md",
+    replaceTheRegex: regexes.import_export_statements,
+    replaceWith: `drash_middleware@v{{ thisModulesLatestVersion }}`,
+  },
+  {
     filename: "./serve_typescript/README.md",
     replaceTheRegex: regexes.import_export_statements,
     replaceWith: `drash_middleware@v{{ thisModulesLatestVersion }}`,
@@ -87,6 +92,11 @@ export const bumpDependencyFiles = [
   },
   {
     filename: "./paladin/README.md",
+    replaceTheRegex: regexes.drash_import_statements,
+    replaceWith: `drash@v${latestDrashVersion}`,
+  },
+  {
+    filename: "./rate_limiter/README.md",
     replaceTheRegex: regexes.drash_import_statements,
     replaceWith: `drash@v${latestDrashVersion}`,
   },

--- a/rate_limiter/README.md
+++ b/rate_limiter/README.md
@@ -1,0 +1,64 @@
+# RateLimiter
+
+RateLimiter helps you secure your Drash applications by limiting the number of
+requests a single user (IP) can request. Inspired by
+[express-rate-limit](https://github.com/nfriedly/express-rate-limit). It is
+configurable and can be used throughout the request-resource-response lifecycle.
+This does not make your application bulletproof, but adds extra security layers.
+
+```typescript
+import { Drash } from "https://deno.land/x/drash@v1.4.4/mod.ts";
+
+// Import the RateLimit middleware function
+import { RateLimit } from "https://deno.land/x/drash_middleware@v0.7.7/rate_limit/mod.ts";
+
+// Instantiate rateLimit
+const rateLimit = RateLimit({
+  timeframe: 15 * 60 * 1000, // 15 minutes
+  maxRequests: 100, // Limit each IP to 100 requests per `timeframe`
+});
+
+// Create your server and plug in paladin to the middleware config
+const server = new Drash.Http.Server({
+  resources: [
+    HomeResource,
+  ],
+  middleware: {
+    before_request: [
+      rateLimit,
+    ],
+  },
+});
+
+server.run({
+  hostname: "localhost",
+  port: 1447,
+});
+
+console.log(`Server running at ${server.hostname}:${server.port}`);
+```
+
+## Configuration
+
+You can customise how many requests a user is allowed in a given time
+
+### `timeframe`
+
+This is how long a user is allowed X amount of requests, before the counter
+resets. This option is required, and must be in milliseconds.
+
+```typescript
+const rateLimit = RateLimit({
+  timeframe: 15 * 60 * 1000, // 15 minutes
+});
+```
+
+### `maxRequests`
+
+This is how many requests a user is allowed within an X amount of time
+
+```typescript
+const rateLimit = RateLimit({
+  maxRequests: 100, // limit each IP to 100 requests per `timeframe``
+});
+```

--- a/rate_limiter/mod.ts
+++ b/rate_limiter/mod.ts
@@ -1,0 +1,82 @@
+import { Drash } from "../deps.ts";
+
+export interface Configs {
+  /* How long (in milliseconds) an IP is allocated the `maxRequest`s */
+  timeframe: number;
+  /* Number of requests an IP is allowed within the `timeframe` */
+  maxRequests: number;
+}
+
+class MemoryStore {
+  private hits: Record<string, number> = {};
+  private resetTime: Date;
+
+  constructor(timeframe: number) {
+    this.resetTime = this.calculateNextResetTime(timeframe);
+  }
+
+  private calculateNextResetTime(timeframe: number): Date {
+    const d = new Date();
+    d.setMilliseconds(d.getMilliseconds() + timeframe);
+    return d;
+  }
+
+  public increment(key: string): {
+    current: number;
+    resetTime: Date;
+  } {
+    if (this.hits[key]) {
+      this.hits[key]++;
+    } else {
+      this.hits[key] = 1;
+    }
+    return {
+      current: this.hits[key],
+      resetTime: this.resetTime,
+    };
+  }
+}
+
+/**
+ * A middleware to help secure you applications, inspired by https://github.com/nfriedly/express-rate-limit.
+ *
+ * @param configs - See Configs
+ */
+export function RateLimit(
+  configs: Configs,
+): (request: Drash.Http.Request, response?: Drash.Http.Response) => void {
+  const { timeframe, maxRequests } = configs;
+  const memoryStore = new MemoryStore(timeframe);
+
+  function rateLimit(
+    request: Drash.Http.Request,
+    response?: Drash.Http.Response,
+  ) {
+    if (response) {
+      const originalRequest = Reflect.get(request, "original_request");
+      const key = originalRequest.conn.remoteAddr;
+      const { current, resetTime } = memoryStore.increment(key);
+      const requestsRemaining = Math.max(maxRequests - current, 0);
+
+      response.headers.set("X-RateLimit-Limit", maxRequests.toString());
+      response.headers.set(
+        "X-RateLimit-Remaining",
+        requestsRemaining.toString(),
+      );
+      response.headers.set("Date", new Date().toUTCString());
+      response.headers.set(
+        "X-RateLimit-Reset",
+        Math.ceil(resetTime.getTime() / 1000).toString(),
+      );
+
+      if (maxRequests && current > maxRequests) {
+        response.headers.set(
+          "Retry-After",
+          Math.ceil(timeframe / 1000).toString(),
+        );
+      }
+    }
+  }
+
+  return rateLimit;
+}

--- a/rate_limiter/tests/mod_test.ts
+++ b/rate_limiter/tests/mod_test.ts
@@ -1,0 +1,92 @@
+import { Rhum } from "../../test_deps.ts";
+import { RateLimit } from "../mod.ts";
+import { Drash } from "../../deps.ts";
+
+class Resource extends Drash.Http.Resource {
+  static paths = ["/"];
+  public GET() {
+    this.response.body = "Hello world!";
+    return this.response;
+  }
+}
+
+const rateLimit = RateLimit({
+  timeframe: 15 * 60 * 1000,
+  maxRequests: 3,
+});
+
+const server = new Drash.Http.Server({
+  resources: [Resource],
+  middleware: {
+    before_request: [
+      rateLimit,
+    ],
+  },
+});
+const runOptions = {
+  hostname: "localhost",
+  port: 1667,
+};
+
+Rhum.testPlan("RateLimit - mod_test.ts", () => {
+  Rhum.testSuite("Not hit limit", () => {
+    Rhum.testCase(
+      "Header should be set correctly when you request and haven't hit the limit",
+      async () => {
+        await server.run(runOptions);
+        let res;
+        let headers;
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        headers = res.headers;
+        console.log(headers);
+        Rhum.asserts.assertEquals(headers.get("date"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-limit"), "3");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-remaining"), "2");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-reset"), "TODO"); // how do we assert this as we don't know the actual date?
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        headers = res.headers;
+        console.log(headers);
+        await server.close();
+        Rhum.asserts.assertEquals(headers.get("date"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-limit"), "3");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-remaining"), "1");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-reset"), "TODO"); // how do we assert this as we don't know the actual date?
+      },
+    );
+  });
+  Rhum.testSuite("Has hit limit", () => {
+    Rhum.testCase(
+      "Header should be set correctly when you request and have hit the limit",
+      async () => {
+        await server.run(runOptions);
+        let res;
+        let headers;
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        headers = res.headers;
+        Rhum.asserts.assertEquals(headers.get("date"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-limit"), "3");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-remaining"), "0");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-reset"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-retry-after"), undefined);
+        res = await fetch("http://localhost:1667/");
+        await res.arrayBuffer();
+        headers = res.headers;
+        await server.close();
+        Rhum.asserts.assertEquals(headers.get("date"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-limit"), "3");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-remaining"), "0");
+        Rhum.asserts.assertEquals(headers.get("x-ratelimit-reset"), "TODO"); // how do we assert this as we don't know the actual date?
+        Rhum.asserts.assertEquals(headers.get("x-retry-after"), "TODO"); // how do we assert this as we don't know the actual date?
+      },
+    );
+  });
+});
+
+Rhum.run();


### PR DESCRIPTION
Fixed #85 

Relies on drash being able to pass in the response object for BEFORE middleware, see https://github.com/drashland/deno-drash-middleware/issues/97#issuecomment-850836170
